### PR TITLE
Defect - widget state incorrect

### DIFF
--- a/TapB4UNap.xcodeproj/project.pbxproj
+++ b/TapB4UNap.xcodeproj/project.pbxproj
@@ -33,8 +33,8 @@
 		5BA7F2F81CC33FC2003174E8 /* HealthStore+ExtensionAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA7F2F71CC33FC2003174E8 /* HealthStore+ExtensionAuthorization.swift */; };
 		5BA7F2FA1CC39C76003174E8 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA7F2F91CC39C76003174E8 /* Utils.swift */; };
 		5BA7F2FB1CC39C76003174E8 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA7F2F91CC39C76003174E8 /* Utils.swift */; };
-		5BBB932C1CE740E800C2A730 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBB932B1CE740E800C2A730 /* MainViewController.swift */; };
 		5BBB932A1CE7401100C2A730 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 5BBB93291CE7401100C2A730 /* Settings.bundle */; };
+		5BBB932C1CE740E800C2A730 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBB932B1CE740E800C2A730 /* MainViewController.swift */; };
 		5BBF48B51ADA6498005F3E8D /* Defaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5BBF48B41ADA6498005F3E8D /* Defaults.plist */; };
 		5BD07E301A05368D000A6E9E /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5BD07E2F1A05368D000A6E9E /* LaunchScreen.xib */; };
 		5BD07E3A1A071100000A6E9E /* hov6CQ-1280x400.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5BD07E391A071100000A6E9E /* hov6CQ-1280x400.jpg */; };
@@ -124,8 +124,8 @@
 		5BA7F2F51CC31F39003174E8 /* TapB4UNapErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TapB4UNapErrorTests.swift; sourceTree = "<group>"; };
 		5BA7F2F71CC33FC2003174E8 /* HealthStore+ExtensionAuthorization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HealthStore+ExtensionAuthorization.swift"; sourceTree = "<group>"; };
 		5BA7F2F91CC39C76003174E8 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
-		5BBB932B1CE740E800C2A730 /* MainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		5BBB93291CE7401100C2A730 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
+		5BBB932B1CE740E800C2A730 /* MainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		5BBF48B41ADA6498005F3E8D /* Defaults.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Defaults.plist; sourceTree = "<group>"; };
 		5BD07E2F1A05368D000A6E9E /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = "<group>"; };
 		5BD07E391A071100000A6E9E /* hov6CQ-1280x400.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "hov6CQ-1280x400.jpg"; sourceTree = "<group>"; };
@@ -617,7 +617,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -661,7 +660,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -684,8 +682,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = TapB4UNap/TapB4UNap.entitlements;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -696,7 +694,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cweatureapps.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "57e245bd-083f-4260-be0f-7516bf214cae";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Debug;
 		};
@@ -705,8 +703,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = TapB4UNap/TapB4UNap.entitlements;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -717,7 +715,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cweatureapps.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "57e245bd-083f-4260-be0f-7516bf214cae";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Release;
 		};
@@ -726,6 +724,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -738,6 +737,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "au.com.cweature.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TapB4UNap.app/TapB4UNap";
 			};
@@ -748,6 +748,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -756,6 +757,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "au.com.cweature.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TapB4UNap.app/TapB4UNap";
 			};
 			name = Release;

--- a/TapB4UNapCommon/TimerViewController.swift
+++ b/TapB4UNapCommon/TimerViewController.swift
@@ -40,11 +40,11 @@ class TimerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clearColor()
-        refreshUI()
     }
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
+        refreshUI()
         if let sleepSample = timeKeeper.sleepSample() {
             if sleepSample.isSleeping() {
                 startSleepingTimer()

--- a/docs/TestCases.md
+++ b/docs/TestCases.md
@@ -3,29 +3,33 @@
 ## UI interactions
 
 ### From widget
-Prerequisite: screen is in initial state, with "Tap sleep to start"
+Pre-condition: app is closed. Launch the widget. screen is in initial state, with "Tap sleep to start"
 1. Tap sleep, counter begins. The time shown should not shift around with each 1 second tick
 2. Tap Reset, goes back to starting screen
-3. Start sleep again. Tap on Wake, it will show how long you slept for
-4. Tap on reset
-    4a. immediately tap on reset, screen should reset
-    4b. tap on reset only after timeout, screen should reset
-5. confirm saved OK in HealthKit
+3. Start sleep again. Tap on Wake, it will show how long you slept for.
+4. open up the (app), confirm it also shows the sleeping time
+5. Tap on reset
+    5a. immediately tap on reset, screen should reset
+    5b. tap on reset only after timeout, screen should reset
+6. open up the (app), confirm that screen state is also reset
+7. confirm saved OK in HealthKit
+
 
 ### From app
-Repeat the above test from the app
-
+Pre-condition: app is closed. Launch the app. screen is in initial state, with "Tap sleep to start"
+Repeat the above test from the app.
+In step 4 and 6, verify for the widget, rather than the app
 
 
 ## Screen reset
 
 ### from widget
-Prerequisite: After successful save
+Pre-condition: After successful save
 1. Close widget and open it immediately, the finish screen is still shown.
 2. close widget and open it, wait for the reset timeout, and then open it again. The starting screen is shown
 
 ### from app
-Prerequisite: After successful save
+Pre-condition: After successful save
 1. Background the app, and open it again back immediately, the finish screen is still shown.
 2. Background the app, wait for the reset timeout, and then open it again. The starting screen is shown
 
@@ -33,14 +37,12 @@ Prerequisite: After successful save
 
 ## Editing the time
 
-Prerequisite: After successful save
-Variations: Execute test case for both App and TX
+### From the App
+Pre-condition: After successful save
 
 1. Tap adjust. 
 Expected:
 - adjustment screen opens
-    App: modal present of adjustment screen
-    TX: opens the app at the adjustment screen
 - start and end times should correspond to the most recent sleep
 - sleep duration should be shown, including seconds
 
@@ -68,6 +70,15 @@ Expected:
 5. Tap adjust again
 - start and end times should correspond to the most recent sleep (from the adjustment)
 - sleep duration should be shown, including seconds
+
+### From the widget
+Repeat above test case, but initiate the adjust from the widget. It will open up the app to do the adjust.
+
+### Adjusting a deleted sample
+Pre-condition: saved into HealthKit, and on the adjust screen
+1. Go into Apple Health, and delete the sample
+2. Try to adjust it from TapB4UNap, and tap Save
+Expected: Something went wrong error message
 
 
 


### PR DESCRIPTION
Fix up defect where widget doesn't pick up a finished or reset state correctly, if the state was changed from the app

Widget would be ok if it was ticking, but not for the other states. Only reproducible on a device.
Seems as though the device might keep the widget in memory for a short time, and not unload it, hence viewDidLoad doesn't get called every time. Moving refreshUI to viewWillAppear solves the problem.
